### PR TITLE
fix: セキュリティ修正 Medium+Low (#7,#8,#9,#10)

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -2,6 +2,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ModelDefinitionConfig } from "../../config/types.js";
+import { validateProviderBaseUrl } from "../../config/types.models.js";
 import {
   prepareProviderDynamicModel,
   resolveProviderRuntimePlugin,
@@ -160,6 +161,16 @@ export function buildInlineProviderModels(
     const providerHeaders = sanitizeModelHeaders(entry?.headers, {
       stripSecretRefMarkers: true,
     });
+    if (entry?.baseUrl) {
+      const urlCheck = validateProviderBaseUrl(entry.baseUrl);
+      if (!urlCheck.valid) {
+        return [];
+      }
+      if (urlCheck.warning) {
+        // eslint-disable-next-line no-console
+        console.warn(`[model-provider] ${trimmed}: ${urlCheck.warning}`);
+      }
+    }
     return (entry?.models ?? []).map((model) => ({
       ...model,
       provider: trimmed,

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -29,6 +29,7 @@ const log = createSubsystemLogger("openrouter-model-capabilities");
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
 const DISK_CACHE_FILENAME = "openrouter-models.json";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1_000; // 24 hours
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,6 +73,7 @@ export interface OpenRouterModelCapabilities {
 
 interface DiskCachePayload {
   models: Record<string, OpenRouterModelCapabilities>;
+  updatedAt?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +96,7 @@ function writeDiskCache(map: Map<string, OpenRouterModelCapabilities>): void {
     }
     const payload: DiskCachePayload = {
       models: Object.fromEntries(map),
+      updatedAt: Date.now(),
     };
     writeFileSync(resolveDiskCachePath(), JSON.stringify(payload), "utf-8");
   } catch (err: unknown) {
@@ -127,8 +130,14 @@ function readDiskCache(): Map<string, OpenRouterModelCapabilities> | undefined {
     if (!payload || typeof payload !== "object") {
       return undefined;
     }
-    const models = (payload as DiskCachePayload).models;
+    const cachePayload = payload as DiskCachePayload;
+    const models = cachePayload.models;
     if (!models || typeof models !== "object") {
+      return undefined;
+    }
+    // Expire cache after TTL
+    if (cachePayload.updatedAt && Date.now() - cachePayload.updatedAt > CACHE_TTL_MS) {
+      log.debug("OpenRouter disk cache expired (TTL exceeded)");
       return undefined;
     }
     const map = new Map<string, OpenRouterModelCapabilities>();

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1773,12 +1773,23 @@
       image(token) {
         return renderMarkdownImage(token);
       },
+      // Sanitize link href to block javascript: and data: URLs (XSS prevention)
+      link(token) {
+        const href = token.href || "";
+        const safeHref = /^\s*(javascript|data|vbscript):/i.test(href) ? "#" : escapeHtmlAttr(href);
+        const title = token.title ? ` title="${escapeHtmlAttr(token.title)}"` : "";
+        const text = token.tokens ? this.parser.parseInline(token.tokens) : escapeHtml(token.text);
+        return `<a href="${safeHref}"${title} rel="noopener noreferrer">${text}</a>`;
+      },
     },
   });
 
-  // Simple marked parse (escaping handled in renderers)
+  // Safe marked parse with post-processing sanitization
   function safeMarkedParse(text) {
-    return marked.parse(text);
+    let html = marked.parse(text);
+    // Strip any residual event handler attributes as defense-in-depth
+    html = html.replace(/\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi, "");
+    return html;
   }
 
   // Search input

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -72,6 +72,31 @@ export type ModelProviderConfig = {
   models: ModelDefinitionConfig[];
 };
 
+/**
+ * Validate that a provider baseUrl uses a safe protocol.
+ * Blocks non-HTTP(S) schemes and warns on non-HTTPS in production.
+ */
+export function validateProviderBaseUrl(baseUrl: string): { valid: boolean; warning?: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return { valid: false, warning: `Invalid URL: ${baseUrl}` };
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return { valid: false, warning: `Unsupported protocol: ${parsed.protocol}` };
+  }
+  const isLocalhost =
+    parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1";
+  if (parsed.protocol === "http:" && !isLocalhost) {
+    return {
+      valid: true,
+      warning: `Non-HTTPS baseUrl "${baseUrl}" — API keys may be transmitted in cleartext`,
+    };
+  }
+  return { valid: true };
+}
+
 export type BedrockDiscoveryConfig = {
   enabled?: boolean;
   region?: string;

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -156,21 +156,21 @@ describe("auth rate limiter", () => {
 
   // ---------- loopback exemption ----------
 
-  it.each(["127.0.0.1", "::1"])("exempts loopback address %s by default", (ip) => {
+  it.each(["127.0.0.1", "::1"])("rate-limits loopback address %s by default", (ip) => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure(ip);
-    expect(limiter.check(ip).allowed).toBe(true);
+    expect(limiter.check(ip).allowed).toBe(false);
   });
 
-  it("rate-limits loopback when exemptLoopback is false", () => {
+  it("exempts loopback when exemptLoopback is true", () => {
     limiter = createAuthRateLimiter({
       maxAttempts: 1,
       windowMs: 60_000,
       lockoutMs: 60_000,
-      exemptLoopback: false,
+      exemptLoopback: true,
     });
     limiter.recordFailure("127.0.0.1");
-    expect(limiter.check("127.0.0.1").allowed).toBe(false);
+    expect(limiter.check("127.0.0.1").allowed).toBe(true);
   });
 
   // ---------- reset ----------

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -29,7 +29,7 @@ export interface RateLimitConfig {
   windowMs?: number;
   /** Lockout duration in milliseconds after the limit is exceeded.  @default 300_000 (5 min) */
   lockoutMs?: number;
-  /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
+  /** Exempt loopback (localhost) addresses from rate limiting.  @default false */
   exemptLoopback?: boolean;
   /** Background prune interval in milliseconds; set <= 0 to disable auto-prune.  @default 60_000 */
   pruneIntervalMs?: number;
@@ -96,7 +96,7 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
   const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
   const lockoutMs = config?.lockoutMs ?? DEFAULT_LOCKOUT_MS;
-  const exemptLoopback = config?.exemptLoopback ?? true;
+  const exemptLoopback = config?.exemptLoopback ?? false;
   const pruneIntervalMs = config?.pruneIntervalMs ?? PRUNE_INTERVAL_MS;
 
   const entries = new Map<string, RateLimitEntry>();

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -15,4 +15,10 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("https://fonts.googleapis.com");
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
+
+  it("includes form-action and upgrade-insecure-requests directives", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("form-action 'none'");
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -3,15 +3,21 @@ export function buildControlUiCspHeader(): string {
   // (UI uses a lot of inline style attributes in templates).
   // Keep Google Fonts origins explicit in CSP for deployments that load
   // external Google Fonts stylesheets/font files.
+  //
+  // NOTE: style-src 'unsafe-inline' is retained because the UI templates
+  // heavily rely on inline style attributes. Migrating to nonce-based styles
+  // requires coordinated template changes tracked separately.
   return [
     "default-src 'self'",
     "base-uri 'none'",
     "object-src 'none'",
     "frame-ancestors 'none'",
+    "form-action 'none'",
     "script-src 'self'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
+    "upgrade-insecure-requests",
   ].join("; ");
 }

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -1,11 +1,21 @@
 import type { DatabaseSync } from "node:sqlite";
 
+const SAFE_TABLE_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function validateTableName(name: string, label: string): void {
+  if (!SAFE_TABLE_NAME_RE.test(name)) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}. Must match ${SAFE_TABLE_NAME_RE}.`);
+  }
+}
+
 export function ensureMemoryIndexSchema(params: {
   db: DatabaseSync;
   embeddingCacheTable: string;
   ftsTable: string;
   ftsEnabled: boolean;
 }): { ftsAvailable: boolean; ftsError?: string } {
+  validateTableName(params.embeddingCacheTable, "embeddingCacheTable");
+  validateTableName(params.ftsTable, "ftsTable");
   params.db.exec(`
     CREATE TABLE IF NOT EXISTS meta (
       key TEXT PRIMARY KEY,
@@ -88,6 +98,7 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
+  validateTableName(column, "column");
   const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
   if (rows.some((row) => row.name === column)) {
     return;


### PR DESCRIPTION
## Summary

Issue #7, #8, #9, #10 のセキュリティ修正をまとめて対応。

### #7 Medium: SQLiteテーブル名インジェクション
- `memory-schema.ts`: テーブル名・カラム名に `/^[a-zA-Z_][a-zA-Z0-9_]*$/` ホワイトリスト検証を追加

### #8 Medium: HTML Export XSS
- `template.js`: `link` renderer追加（`javascript:`/`data:`/`vbscript:` URL をブロック）
- `safeMarkedParse` に `on*` イベントハンドラ属性の除去を追加（defense-in-depth）

### #9 Medium: カスタムbaseURL任意プロキシ
- `types.models.ts`: `validateProviderBaseUrl()` 追加（プロトコル検証、非HTTPS警告）
- `model.ts`: プロバイダモデル構築時にURL検証を実行
- `openrouter-model-capabilities.ts`: ディスクキャッシュに24時間TTLを追加

### #10 Low: CSP / Rate limiter / markdown-it
- `control-ui-csp.ts`: `form-action 'none'` と `upgrade-insecure-requests` 追加
- `auth-rate-limit.ts`: `exemptLoopback` デフォルトを `true` → `false` に変更
- `markdown-it`: 既に `^14.1.1` でReDoS修正済み（対応不要）

## Test plan
- [x] `vitest run src/gateway/control-ui-csp.test.ts` — passed
- [x] `vitest run src/gateway/auth-rate-limit.test.ts` — passed
- [x] TypeScript type check (`tsc --noEmit`) — no new errors

Closes #7, Closes #8, Closes #9, Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)